### PR TITLE
Wrap routed screens with SelectionArea via GoRouter; make MemoNotifier injectable and add restore logic/tests

### DIFF
--- a/lib/core/app.dart
+++ b/lib/core/app.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:memomemo/core/app_theme.dart';
 import 'package:memomemo/features/screens/memo_list_screen.dart';
+import 'package:memomemo/features/screens/new_memo_modal.dart';
 import 'package:memomemo/features/screens/onboarding_screen.dart';
+import 'package:memomemo/features/screens/setting_screen.dart';
 
 class MemoMemoApp extends StatelessWidget {
   final bool isFirstLaunch;
@@ -10,11 +13,42 @@ class MemoMemoApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    final router = GoRouter(
+      initialLocation: isFirstLaunch ? '/onboarding' : '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, __) => const SelectionArea(child: MemoListScreen()),
+        ),
+        GoRoute(
+          path: '/onboarding',
+          builder: (context, state) {
+            final fromSettings =
+                state.uri.queryParameters['fromSettings'] == 'true';
+            return SelectionArea(
+              child: OnboardingScreen(fromSettings: fromSettings),
+            );
+          },
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (_, __) => const SelectionArea(child: SettingScreen()),
+        ),
+        GoRoute(
+          path: '/new',
+          pageBuilder: (context, state) => MaterialPage(
+            fullscreenDialog: true,
+            child: const SelectionArea(child: NewMemoModal()),
+          ),
+        ),
+      ],
+    );
+
+    return MaterialApp.router(
       debugShowCheckedModeBanner: false, // 右上の帯を消す
       title: '気分×色メモ',
       theme: appTheme, // 作成したテーマを適用
-      home: isFirstLaunch ? const OnboardingScreen() : const MemoListScreen(),
+      routerConfig: router,
     );
   }
 }

--- a/lib/core/provider/memo_state.dart
+++ b/lib/core/provider/memo_state.dart
@@ -6,19 +6,31 @@ import '../data/memo_repository.dart';
 
 // プロバイダー定義
 // UI側からは ref.watch(memoNotifierProvider) でこのNotifierの状態（リスト）を監視します。
-final memoNotifierProvider = AsyncNotifierProvider<MemoNotifier, List<Memo>>(
-  () {
-    return MemoNotifier();
-  },
-);
+final memoNotifierProvider = AsyncNotifierProvider<MemoNotifier, List<Memo>>(MemoNotifier.new);
 
 class MemoNotifier extends AsyncNotifier<List<Memo>> {
+  MemoNotifier({MemoRepository Function()? repositoryBuilder, String Function()? idGenerator})
+      : _repositoryBuilder = repositoryBuilder,
+        _generateId = idGenerator ?? _defaultUuid.v4;
+
+  static const _defaultUuid = Uuid();
+  final MemoRepository Function()? _repositoryBuilder;
+  final String Function() _generateId;
+
+  MemoRepository _resolveRepository() {
+    final builder = _repositoryBuilder;
+    if (builder != null) {
+      return builder();
+    }
+    return ref.read(memoRepositoryProvider);
+  }
+
   Future<void> backupToCloud() async {
     final currentList = state.value ?? [];
 
     if (currentList.isEmpty) return;
 
-    final repository = ref.read(memoRepositoryProvider);
+    final repository = _resolveRepository();
     await repository.saveToCloud(currentList);
   }
 
@@ -30,14 +42,14 @@ class MemoNotifier extends AsyncNotifier<List<Memo>> {
 
   /// リポジトリからデータを全件取得
   List<Memo> _fetchAll() {
-    final repository = ref.read(memoRepositoryProvider);
+    final repository = _resolveRepository();
     return repository.fetchAll();
   }
 
   /// 内部ヘルパー: データを保存し、同時に画面の状態（state）も更新する
   /// これを呼ぶだけで、UIは自動的に再描画されます。
   Future<void> _saveAndRefresh(List<Memo> newMemos) async {
-    final repository = ref.read(memoRepositoryProvider);
+    final repository = _resolveRepository();
 
     // 1. 永続化（スマホ本体への保存）
     await repository.saveAll(newMemos);
@@ -56,7 +68,7 @@ class MemoNotifier extends AsyncNotifier<List<Memo>> {
 
     // ドメイン層のファクトリを使って、完全なMemoオブジェクトを生成
     final newMemo = Memo.create(
-      id: const Uuid().v4(), // ここでユニークIDを発行
+      id: _generateId(), // ここでユニークIDを発行
       body: body,
       mood: mood,
     );
@@ -100,8 +112,21 @@ class MemoNotifier extends AsyncNotifier<List<Memo>> {
     return target; // 削除したデータを呼び出し元に返す
   }
 
+  /// 削除したメモを復元する
+  Future<void> restore(Memo memo) async {
+    final currentList = state.value ?? [];
+    // 同じメモが既にリスト内に存在する場合は除外してから先頭に追加する。
+    // SnackBarのアクションを連打しても重複しないようにするため。
+    final newList = [
+      memo,
+      ...currentList.where((existing) => existing.id != memo.id),
+    ];
+
+    await _saveAndRefresh(newList);
+  }
+
   Future<void> deleteAll() async {
-    final repository = ref.read(memoRepositoryProvider);
+    final repository = _resolveRepository();
     // 1. リポジトリに削除命令（スマホのデータを消す）
     await repository.deleteAll();
     // 2. メモリ上の状態も空にする（画面を空っぽにする）

--- a/lib/features/screens/memo_list_screen.dart
+++ b/lib/features/screens/memo_list_screen.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:memomemo/gen/assets.gen.dart';
 import '../../core/provider/memo_state.dart';
 import '../../core/provider/search_state.dart';
 import '../widgets/memo_card.dart';
-import 'new_memo_modal.dart';
-import 'setting_screen.dart';
 
 class MemoListScreen extends ConsumerStatefulWidget {
   const MemoListScreen({super.key});
@@ -41,9 +40,7 @@ class _MemoListScreenState extends ConsumerState<MemoListScreen> {
           IconButton(
             tooltip: '設定画面を開くボタン',
             onPressed: () {
-              Navigator.of(
-                context,
-              ).push(MaterialPageRoute(builder: (_) => const SettingScreen()));
+              context.push('/settings');
             },
             icon: const Icon(Icons.settings), // 色指定を削除（テーマに従う）
           ),
@@ -160,11 +157,6 @@ class _MemoListScreenState extends ConsumerState<MemoListScreen> {
   }
 
   void _openNewMemo(BuildContext context) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        fullscreenDialog: true,
-        builder: (_) => const NewMemoModal(),
-      ),
-    );
+    context.push('/new');
   }
 }

--- a/lib/features/screens/onboarding_screen.dart
+++ b/lib/features/screens/onboarding_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:memomemo/gen/assets.gen.dart';
-import 'memo_list_screen.dart';
 
 class OnboardingScreen extends StatefulWidget {
   final bool fromSettings;
@@ -31,7 +31,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
   Future<void> _finishOnboarding() async {
     if (widget.fromSettings) {
       // 設定画面から来た場合は単に閉じる
-      Navigator.of(context).pop();
+      context.pop();
       return;
     }
 
@@ -39,9 +39,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     await prefs.setBool('isFirstLaunch', false);
 
     if (!mounted) return;
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => const MemoListScreen()),
-    );
+    context.go('/');
   }
 
   final List<Map<String, String>> onboardingData = [

--- a/lib/features/screens/setting_screen.dart
+++ b/lib/features/screens/setting_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:memomemo/core/constants/app_urls.dart';
 //import 'package:memomemo/core/app_colors.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memomemo/core/provider/memo_state.dart';
 import 'package:memomemo/crashlytics.dart';
-import 'onboarding_screen.dart';
 
 class SettingScreen extends ConsumerWidget {
   const SettingScreen({super.key});
@@ -21,7 +21,7 @@ class SettingScreen extends ConsumerWidget {
         leading: IconButton(
           tooltip: '設定画面を閉じるボタン',
           icon: Icon(Icons.arrow_back_ios),
-          onPressed: () => Navigator.pop(context),
+          onPressed: () => context.pop(),
         ),
       ),
       body: ListView(
@@ -141,11 +141,7 @@ class SettingScreen extends ConsumerWidget {
             icon: Icons.help_outline,
             title: '使い方を見る',
             onTap: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (_) => const OnboardingScreen(fromSettings: true),
-                ),
-              );
+              context.push('/onboarding?fromSettings=true');
             },
           ),
           _buildSettingTile(

--- a/lib/features/widgets/memo_card.dart
+++ b/lib/features/widgets/memo_card.dart
@@ -39,7 +39,7 @@ class MemoCard extends ConsumerWidget {
               action: SnackBarAction(
                 label: '元に戻す',
                 onPressed: () {
-                  notifier.add(body: removedMemo.body, mood: removedMemo.mood);
+                  notifier.restore(removedMemo);
                 },
               ),
             ),

--- a/test/unit/memo_notifier_test.dart
+++ b/test/unit/memo_notifier_test.dart
@@ -1,20 +1,59 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-//import 'package:memomemo/core/domain/memo.dart';
+import 'package:memomemo/core/domain/memo.dart';
 import 'package:memomemo/core/domain/mood.dart';
 import 'package:memomemo/core/provider/memo_state.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:memomemo/core/data/memo_repository.dart';
+
+class _FakeMemoRepository implements MemoRepository {
+  List<Memo> _storage = [];
+
+  @override
+  Future<void> saveToCloud(List<Memo> memos) async {}
+
+  @override
+  Future<void> saveAll(List<Memo> memos) async {
+    _storage = [...memos];
+  }
+
+  @override
+  List<Memo> fetchAll() => [..._storage];
+
+  @override
+  Future<void> deleteAll() async {
+    _storage = [];
+  }
+}
+
+class _IdGenerator {
+  int _counter = 0;
+  String call() => 'test-id-${_counter++}';
+}
+
+ProviderContainer _createContainer() {
+  final repository = _FakeMemoRepository();
+  final idGenerator = _IdGenerator();
+
+  final container = ProviderContainer(
+    overrides: [
+      memoRepositoryProvider.overrideWithValue(repository),
+      memoNotifierProvider.overrideWith(
+        () => MemoNotifier(
+          repositoryBuilder: () => repository,
+          idGenerator: idGenerator.call,
+        ),
+      ),
+    ],
+  );
+
+  addTearDown(container.dispose);
+  return container;
+}
 
 void main() {
-  // SharedPreferencesのモック（偽物）を準備
-  // これがないと "MissingPluginException" エラー
-  setUp(() {
-    SharedPreferences.setMockInitialValues({});
-  });
 
   test('初期状態は空であること', () {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+    final container = _createContainer();
 
     // プロバイダーの状態を読み込む
     final state = container.read(memoNotifierProvider);
@@ -24,8 +63,7 @@ void main() {
   });
 
   test('メモを追加できること', () async {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+    final container = _createContainer();
 
     final notifier = container.read(memoNotifierProvider.notifier);
 
@@ -45,8 +83,7 @@ void main() {
   });
 
   test('メモを削除できること', () async {
-    final container = ProviderContainer();
-    addTearDown(container.dispose);
+    final container = _createContainer();
     final notifier = container.read(memoNotifierProvider.notifier);
 
     // 1つ追加
@@ -59,5 +96,42 @@ void main() {
     // 空になっているか確認
     final state = container.read(memoNotifierProvider);
     expect(state.value, isEmpty);
+  });
+
+  test('削除したメモを復元でき、メタデータも保持されること', () async {
+    final container = _createContainer();
+    final notifier = container.read(memoNotifierProvider.notifier);
+
+    await notifier.add(body: '復元メモ', mood: Mood.happy);
+    final original = container.read(memoNotifierProvider).value!.first;
+
+    final removed = await notifier.delete(original.id);
+    expect(removed, isNotNull);
+
+    await notifier.restore(removed!);
+
+    final restored = container.read(memoNotifierProvider).value!;
+    expect(restored, hasLength(1));
+    expect(restored.first.id, original.id);
+    expect(restored.first.createdAt, original.createdAt);
+    expect(restored.first.updatedAt, original.updatedAt);
+  });
+
+  test('同じメモを重複復元しないこと', () async {
+    final container = _createContainer();
+    final notifier = container.read(memoNotifierProvider.notifier);
+
+    await notifier.add(body: '重複しない', mood: Mood.calm);
+    final memo = container.read(memoNotifierProvider).value!.first;
+
+    final removed = await notifier.delete(memo.id);
+    expect(removed, isNotNull);
+
+    await notifier.restore(removed!);
+    await notifier.restore(removed);
+
+    final restored = container.read(memoNotifierProvider).value!;
+    expect(restored, hasLength(1));
+    expect(restored.first.id, memo.id);
   });
 }


### PR DESCRIPTION
### Motivation
- 画面ごとのテキスト選択を一貫して有効にするため、`SelectionArea` で各画面をラップしつつルーティングに移行する必要があった。 
- `MemoNotifier` のテスト容易性を高めるため、リポジトリとID生成を差し替え可能にして副作用を切り離したい。 
- スナックバーの「元に戻す」操作でオブジェクトの重複復元を防ぎ、メタデータを保持して復元できるようにしたい。 

### Description
- `MemoMemoApp` を `MaterialApp` から `MaterialApp.router` に切り替え、`GoRouter` を導入して `/`, `/onboarding`, `/settings`, `/new` のルートを定義し各ルートで `SelectionArea` をラップするようにした（`lib/core/app.dart`）。
- 各画面の遷移呼び出しを `Navigator` 直呼びから router API (`context.push`, `context.pop`, `context.go`) に差し替えた（`lib/features/screens/memo_list_screen.dart`, `lib/features/screens/onboarding_screen.dart`, `lib/features/screens/setting_screen.dart`）。
- `MemoNotifier` をテストしやすくするためにコンストラクタでリポジトリビルダとID生成器を受け取れるようにし、デフォルトでは既存の `memoRepositoryProvider` と `Uuid().v4()` を使う実装にした（`lib/core/provider/memo_state.dart`）。
- 削除後の復元ロジック `restore(Memo memo)` を追加し、復元時に同IDの既存エントリを除外して先頭に挿入することで重複復元を防止するようにした（`lib/core/provider/memo_state.dart`）。
- メモカードのUndoアクションを新しい `restore` を呼ぶように変更した（`lib/features/widgets/memo_card.dart`）。
- `MemoNotifier` を差し替え可能にしたことに合わせ、永続層の副作用を伴わないフェイク実装と安定IDジェネレータを使ったユニットテストを追加した（`test/unit/memo_notifier_test.dart`）。

### Testing
- ユニットテストを追加したファイルは `test/unit/memo_notifier_test.dart` で、`restore` のメタデータ保持と重複復元抑止を含む複数テストを実装しているが、ローカルのCI環境で実行はしていない（自動実行は未実行）。
- この環境でのコマンド実行は一部失敗しており、`dart format` の実行は `dart: command not found` により実行できなかった。 
- `flutter test` はこの環境に `flutter` が存在しないため実行できず、テストは実環境またはCIでの実行を想定している（テストファイルは追加済み）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6936d6a909cc83328e203b1e46feb80d)